### PR TITLE
PyYAML を 6.0.2 に更新し ssconvert インストール時のエラーを修正

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,11 @@ Example
 Release notes
 =============
 
+v0.2.1
+------
+
+* PyYAML を 6.0.2 に更新し ssconvert インストール時のエラーを修正
+
 v0.2.0
 ------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML==6.0
+PyYAML==6.0.2
 python-dateutil==2.8.2
 pytz==2022.1
 six==1.16.0

--- a/spreadsheetconverter/__init__.py
+++ b/spreadsheetconverter/__init__.py
@@ -5,4 +5,4 @@ from .config import Config, YamlConfig
 from .converter import Converter
 
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'


### PR DESCRIPTION
`pip install SpreadsheetConverter ` 実行時に、以下のエラーが発生していました。

```
AttributeError: cython_sources
```

PyYAML のバージョンを上げることで回避できましたので、修正したプルリクエストを上げます。
ご確認のほど、よろしくお願いいたします。